### PR TITLE
Prevent inclusion of es6 source in distribution package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,19 @@
         }
       ]
     },
+    "files": [
+      "**/*",
+      "!actions${/*}",
+      "!api${/*}",
+      "!components${/*}",
+      "!containers${/*}",
+      "!reducers${/*}",
+      "!store${/*}",
+      "!utils${/*}",
+      "!main.development.js",
+      "!index.js",
+      "!routes.js"
+    ],
     "win": {
       "target": "nsis"
     },


### PR DESCRIPTION
Added build.files array to prevent the es6 source from being included in the final app distribution as per Issue